### PR TITLE
Allow comparisons in version listener

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -7,12 +7,12 @@ LaTeX Package keymap for Linux
 	{	"keys": ["ctrl+b"],
 		"context": [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
-			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[0-7]"}],
+			{"key": "ltt_st_build", "operator": "equal", "operand": "<3080"}],
 		"command": "latextools_build_selector"},
 	{	"keys": ["ctrl+shift+b"],
 		"context": [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
-			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[0-7]"}],
+			{"key": "ltt_st_build", "operator": "equal", "operand": "<3080"}],
 		"command": "latextools_build_selector",
 			"args": {"select": true}},
 

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -7,12 +7,12 @@ LaTeX Package keymap for OS X
 	{	"keys": ["super+b"],
 		"context": [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
-			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[0-7]"}],
+			{"key": "ltt_st_build", "operator": "equal", "operand": "<3080"}],
 		"command": "latextools_build_selector"},
 	{	"keys": ["super+shift+b"],
 		"context": [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
-			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[0-7]"}],
+			{"key": "ltt_st_build", "operator": "equal", "operand": "<3080"}],
 		"command": "latextools_build_selector",
 			"args": {"select": true}},
 

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -7,12 +7,12 @@ LaTeX Package keymap for Windows
 	{	"keys": ["ctrl+b"],
 		"context": [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
-			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[0-7]"}],
+			{"key": "ltt_st_build", "operator": "equal", "operand": "<3080"}],
 		"command": "latextools_build_selector"},
 	{	"keys": ["ctrl+shift+b"],
 		"context": [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
-			{"key": "ltt_st_build", "operator": "regex_match", "operand": "2|30[0-7]"}],
+			{"key": "ltt_st_build", "operator": "equal", "operand": "<3080"}],
 		"command": "latextools_build_selector",
 			"args": {"select": true}},
 

--- a/latextools_sublime_version_listener.py
+++ b/latextools_sublime_version_listener.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import sublime
 import sublime_plugin
 
+import operator as opi
 import re
 
 VERSION = sublime.version()
@@ -35,10 +36,23 @@ class LatextoolsSublimeVersionEventListener(sublime_plugin.EventListener):
             return None
 
     def _equal(self, operand):
-        return VERSION == operand
+        # if the operand starts with <, >, <=, >=, (=, or ==)
+        # change the compare operator correspondingly and strip the operand
+        if operand[0:1] in "<>=":
+            i = 1 if operand[1:2] != "=" else 2
+            comp_str, operand = operand[:i], operand[i:]
+            compare = {
+                "<": opi.lt,
+                ">": opi.gt,
+                "<=": opi.le,
+                ">=": opi.ge
+            }.get(comp_str, opi.eq)
+        else:
+            compare = opi.eq
+        return compare(VERSION, operand.strip())
 
     def _not_equal(self, operand):
-        return VERSION != operand
+        return not self._equal(operand)
 
     def _regex_match(self, operand):
         return re.match(operand, VERSION, re.UNICODE) is not None


### PR DESCRIPTION
This changes the `equal` operator to also accept version preceded by a comparator, e.g. `>=3118`. This comparator will be parsed and striped of the operand.

I think this is better readable than regex and more     convenient, e.g. used in Package Control.
