### PR TITLE
Rename the context

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -7,12 +7,12 @@ LaTeX Package keymap for Linux
 	{	"keys": ["ctrl+b"],
 		"context": [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
-			{"key": "ltt_st_build", "operator": "equal", "operand": "<3080"}],
+			{"key": "latextools.st_version", "operator": "equal", "operand": "<3080"}],
 		"command": "latextools_build_selector"},
 	{	"keys": ["ctrl+shift+b"],
 		"context": [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
-			{"key": "ltt_st_build", "operator": "equal", "operand": "<3080"}],
+			{"key": "latextools.st_version", "operator": "equal", "operand": "<3080"}],
 		"command": "latextools_build_selector",
 			"args": {"select": true}},
 

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -7,12 +7,12 @@ LaTeX Package keymap for OS X
 	{	"keys": ["super+b"],
 		"context": [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
-			{"key": "ltt_st_build", "operator": "equal", "operand": "<3080"}],
+			{"key": "latextools.st_version", "operator": "equal", "operand": "<3080"}],
 		"command": "latextools_build_selector"},
 	{	"keys": ["super+shift+b"],
 		"context": [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
-			{"key": "ltt_st_build", "operator": "equal", "operand": "<3080"}],
+			{"key": "latextools.st_version", "operator": "equal", "operand": "<3080"}],
 		"command": "latextools_build_selector",
 			"args": {"select": true}},
 

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -7,12 +7,12 @@ LaTeX Package keymap for Windows
 	{	"keys": ["ctrl+b"],
 		"context": [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
-			{"key": "ltt_st_build", "operator": "equal", "operand": "<3080"}],
+			{"key": "latextools.st_version", "operator": "equal", "operand": "<3080"}],
 		"command": "latextools_build_selector"},
 	{	"keys": ["ctrl+shift+b"],
 		"context": [
 			{"key": "selector", "operator": "equal", "operand": "text.tex.latex"},
-			{"key": "ltt_st_build", "operator": "equal", "operand": "<3080"}],
+			{"key": "latextools.st_version", "operator": "equal", "operand": "<3080"}],
 		"command": "latextools_build_selector",
 			"args": {"select": true}},
 

--- a/latextools_sublime_version_listener.py
+++ b/latextools_sublime_version_listener.py
@@ -26,7 +26,7 @@ class LatextoolsSublimeVersionEventListener(sublime_plugin.EventListener):
         }
 
     def on_query_context(self, view, key, operator, operand, match_all):
-        if not key == 'ltt_st_build':
+        if not key == 'latextools.st_version':
             return None
 
         try:


### PR DESCRIPTION
This just changes the context name to `latextools.st_version`. We may prefix other similar context with `latextools.` in the future.
